### PR TITLE
CASMTRIAGE-8508 - Criticalservices balanced is not shown correctly by RMS

### DIFF
--- a/src/lib/lib_rms.py
+++ b/src/lib/lib_rms.py
@@ -30,6 +30,7 @@ including Kubernetes and Ceph zone discovery, status checking, and configuration
 """
 
 import os
+import sys
 import json
 import re
 import subprocess
@@ -72,6 +73,7 @@ from src.lib.schema import (
 )
 from src.lib.rrs_constants import (
     NAMESPACE,
+    DYNAMIC_CM,
     DYNAMIC_DATA_KEY,
     SECRET_NAME,
     SECRET_DEFAULT_NAMESPACE,
@@ -173,7 +175,8 @@ class Helper:
             if isinstance(dynamic_cm_data, str):
                 # This means it is an error message
                 logger.error(
-                    "Error fetching dynamic ConfigMap data: %s", dynamic_cm_data,
+                    "Error fetching dynamic ConfigMap data: %s",
+                    dynamic_cm_data,
                 )
                 return
             yaml_content = dynamic_cm_data.get(DYNAMIC_DATA_KEY, None)
@@ -943,6 +946,39 @@ class criticalServicesHelper:
                 if not zone or not node or not pod_name:
                     continue  # skip invalid pod entries
                 zone_pod_map.setdefault(zone, {}).setdefault(node, []).append(pod_name)
+
+            # There might be a case where pods are not spread across all zones which will
+            # result in zone_pod_map not having the entry of those zones.
+            # To address this, we will fetch the zones from the dynamic configmap.
+            dynamic_cm_data = ConfigMapHelper.read_configmap(NAMESPACE, DYNAMIC_CM)
+            if isinstance(dynamic_cm_data, str):
+                logger.error(
+                    "Could not read dynamic configmap %s: %s",
+                    DYNAMIC_CM,
+                    dynamic_cm_data,
+                )
+                sys.exit(1)
+            yaml_content = dynamic_cm_data.get(DYNAMIC_DATA_KEY, None)
+            if not yaml_content:
+                logger.error(
+                    "No content found under %s in rrs-mon-dynamic configmap",
+                    DYNAMIC_DATA_KEY,
+                )
+                sys.exit(1)
+
+            dynamic_data: DynamicDataSchema = yaml.safe_load(yaml_content)
+            k8s_zones = list(dynamic_data["zone"]["k8s_zones"].keys())
+
+            for zone in k8s_zones:
+                nodes = dynamic_data["zone"]["k8s_zones"][zone]
+                # In the event of a rack failure, the corresponding zone will not have any running pods, which is expected.
+                # In this case, the balanced status should be set to 'true'.
+                # Therefore, we check if at least one node in the zone has a 'Ready' status
+                # to ensure that empty entries are added to the zone_pod_map.
+                if zone not in zone_pod_map and any(
+                    node["status"] == "Ready" for node in nodes
+                ):
+                    zone_pod_map[zone] = {}
 
             counts = [
                 sum(len(pods) for pods in zone.values())

--- a/src/lib/lib_rms.py
+++ b/src/lib/lib_rms.py
@@ -971,7 +971,7 @@ class criticalServicesHelper:
 
             for zone in k8s_zones:
                 nodes = dynamic_data["zone"]["k8s_zones"][zone]
-                # In the event of a rack failure, the corresponding zone will not have any running pods, which is expected.
+                # In the event of rack failure, the corresponding zone will not have any pods, which is expected.
                 # In this case, the balanced status should be set to 'true'.
                 # Therefore, we check if at least one node in the zone has a 'Ready' status
                 # to ensure that empty entries are added to the zone_pod_map.

--- a/src/rrs/rms/rms.py
+++ b/src/rrs/rms/rms.py
@@ -690,8 +690,6 @@ if __name__ == "__main__":
                 "RMS was in 'Monitoring' state - starting monitoring loop to resume previous incomplete process"
             )
             threading.Thread(target=monitor.monitoring_loop, daemon=True).start()
-                
-                
         update_zone_status(state_manager)
         update_critical_services(state_manager, True)
         app.logger.info("Starting the main loop")

--- a/src/rrs/rms/rms.py
+++ b/src/rrs/rms/rms.py
@@ -690,11 +690,11 @@ if __name__ == "__main__":
                 "RMS was in 'Monitoring' state - starting monitoring loop to resume previous incomplete process"
             )
             threading.Thread(target=monitor.monitoring_loop, daemon=True).start()
-
-        update_critical_services(state_manager, True)
+                
+                
         update_zone_status(state_manager)
+        update_critical_services(state_manager, True)
         app.logger.info("Starting the main loop")
-
         while True:
             if state_manager.get_state() != RMSState.MONITORING:
                 rms_state = RMSState.WAITING
@@ -711,8 +711,8 @@ if __name__ == "__main__":
                     state_manager, "rms_state", rms_state.value
                 )
                 check_and_create_hmnfd_subscription()
-                update_critical_services(state_manager, True)
                 update_zone_status(state_manager)
+                update_critical_services(state_manager, True)
             else:
                 app.logger.info("Not running main loop as monitoring is running")
                 time.sleep(MAIN_LOOP_WAIT_TIME_INTERVAL)


### PR DESCRIPTION
## Summary and Scope

When the pods are not distributed across racks properly due to kubernetes scheduler failure, RMS is not populating balanced field of those services properly. Its listing the balance as true. This PR addresses this issue.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-8508](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8508)

## Testing

_List the environments in which these changes were tested._

Tested on:

  * `Drax`

Test description:

Simulated the scenario with a test script and tested multiple scenarios.
Scenario 1 - **Without the fix.** When pod distribution is not equal (ie., rack drax-k8s-rack-x6002 is up but there are no pods assigned to nodes running in it). Balance is wrongly showing as `true`

```
ncn-m001:~/sravani # python3 balance_test.py 
{'drax-k8s-rack-x6001': {'ncn-w004': ['istio-ingressgateway-648f5d78fb-djpcg'], 'ncn-w002': ['istio-ingressgateway-648f5d78fb-zq45f']}, 'drax-k8s-rack-x6000': {'ncn-w001': ['istio-ingressgateway-648f5d78fb-z78c8']}}
Distribution array is [2, 1]
Balance for istio-ingressway service is: true
```

Scenario 2 - **With the fix**. When pod distribution is not equal (ie., rack drax-k8s-rack-x6002 is up but there are no pods assigned to nodes running in it). Balance is correctly showing as `false`

```
ncn-m001:~/sravani # python3 balance_test.py 
{'drax-k8s-rack-x6001': {'ncn-w004': ['istio-ingressgateway-648f5d78fb-djpcg'], 'ncn-w002': ['istio-ingressgateway-648f5d78fb-zq45f']}, 'drax-k8s-rack-x6000': {'ncn-w001': ['istio-ingressgateway-648f5d78fb-z78c8']}}
Adding zone drax-k8s-rack-x6002 to zone_pod_map with empty list
Final mapping is -
{'drax-k8s-rack-x6001': {'ncn-w004': ['istio-ingressgateway-648f5d78fb-djpcg'], 'ncn-w002': ['istio-ingressgateway-648f5d78fb-zq45f']}, 'drax-k8s-rack-x6000': {'ncn-w001': ['istio-ingressgateway-648f5d78fb-z78c8']}, 'drax-k8s-rack-x6002': {}}
Distribution array is [2, 1, 0]
Balance for istio-ingressway service is: false
``` 

Scenario 3 - With the fix. When the rack `drax-k8s-rack-x6001` is down (i.e., none of the nodes in that rack are Ready). The balance in this case should be `true` as the above rack should not be considered.

```
ncn-m001:~/sravani # python3 balance_test.py 
{'drax-k8s-rack-x6001': {'ncn-w004': ['istio-ingressgateway-648f5d78fb-djpcg'], 'ncn-w002': ['istio-ingressgateway-648f5d78fb-zq45f']}, 'drax-k8s-rack-x6000': {'ncn-w001': ['istio-ingressgateway-648f5d78fb-z78c8']}}
Final mapping is -
{'drax-k8s-rack-x6001': {'ncn-w004': ['istio-ingressgateway-648f5d78fb-djpcg'], 'ncn-w002': ['istio-ingressgateway-648f5d78fb-zq45f']}, 'drax-k8s-rack-x6000': {'ncn-w001': ['istio-ingressgateway-648f5d78fb-z78c8']}}
Distribution array is [2, 1]
Balance for istio-ingressway service is: true
```

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
